### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,15 +3,18 @@ FROM golang:1.22.0-alpine AS builder
 WORKDIR /app
 COPY . .
 ENV CGO_ENABLED=0
-RUN go mod download
-RUN go build -v -o XrayR -trimpath -ldflags "-s -w -buildid="
+RUN go mod download \
+    && go build -v -o XrayR -trimpath -ldflags "-s -w -buildid="
 
 # Release
-FROM  alpine
+FROM alpine:latest
 # 安装必要的工具包
-RUN  apk --update --no-cache add tzdata ca-certificates \
-    && cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime
-RUN mkdir /etc/XrayR/
+RUN apk --update --no-cache add curl tzdata ca-certificates \
+    && cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime \
+    && mkdir /etc/XrayR/ \
+    && curl -L "https://raw.githubusercontent.com/Loyalsoldier/v2ray-rules-dat/release/geoip.dat" -o /etc/XrayR/geoip.dat \
+    && curl -L "https://raw.githubusercontent.com/Loyalsoldier/v2ray-rules-dat/release/geosite.dat" -o /etc/XrayR/geosite.dat
+
 COPY --from=builder /app/XrayR /usr/local/bin
 
 ENTRYPOINT [ "XrayR", "--config", "/etc/XrayR/config.yml"]


### PR DESCRIPTION
修复缺失 geoip.dat 和 geoip.dat 无法DNS分流的问题，减少RUN以减少镜像层级。